### PR TITLE
Fix: Convert bat file to UTF-8 with BOM for better compatibility

### DIFF
--- a/启动GeminiSuper.bat
+++ b/启动GeminiSuper.bat
@@ -1,5 +1,5 @@
-@echo off
-echo 正在启动 Node.js 程序 main.js...喵~
+锘緻echo off
+echo 姝ｅ湪鍚姩 Node.js 绋嬪簭 main.js...鍠祣
 cd /d "%~dp0"
 node main.js
 pause


### PR DESCRIPTION
将 bat 文件（*bat 文件（批处理文件）默认使用操作系统的默认编码，在中文 Windows 系统中通常是 GBK。*）从 GBK 转换为带 BOM 编码的 UTF-8（*BOM 是一个特殊的标记，告诉文本编辑器或操作系统使用 UTF-8 编码来解释文件。*），以确保在不同默认编码系统上正确显示中文字符。

This pull request converts the bat file to UTF-8 with BOM encoding to ensure proper display of Chinese characters on systems with different default encodings (e.g., GBK on Chinese Windows).