### PR TITLE
[hotfix] 修复Gemini流终止和错误处理处逻辑缺失导致的Gemini回答处理异常问题

### DIFF
--- a/main.js
+++ b/main.js
@@ -789,8 +789,23 @@ app.post('/v1/chat/completions', apiKeyAuth, async (req, res) => {
 
                                         // 修改结束处理
                                         geminiResponse.data.on('end', () => {
-                                            logger.info({ logType: 'gemini_response', message: '\n\nGemini response ended.' }); // 添加换行使                                        geminiResponse.data.on('error', (error) => {
-                                            logger.error({ logType: 'gemini_response', message: 'Gemini response error:', error: error.message });
+                                            logger.info({ logType: 'gemini_response', message: '\n\nGemini response ended.' }); // 添加换行使
+                                            res.write('data: [DONE]\n\n');
+                                            
+                                            if (!res.writableEnded) {
+                                                res.end();
+                                            }
+                                            currentTask = null;
+                                            removeActiveRequest('Gemini');
+                                        });
+
+                                        geminiResponse.data.on('error', (error) => {
+                                            logger.error({ 
+                                                logType: 'gemini_response', 
+                                                message: 'Gemini response error:', 
+                                                error: error.message 
+                                            });
+                                            
                                             if (!res.writableEnded) {
                                                 res.end();
                                             }


### PR DESCRIPTION
问题发现：1）接口响应200时，控制台却同时试图打印error信息。

ps: 上一个pr整出来的bug，测试的时候拿错代码了，测出了个我api有问题的结果便不管了。实际上Gemini流终止处理和错误处理处缺了一段代码，还不报错，但已然偏离了正确的逻辑（ 

测试需谨慎。

![image](https://github.com/user-attachments/assets/b658f4d1-8433-4a97-a6a6-1969dfbc831b)
